### PR TITLE
Fix: Resolve dummy score assignment in image scoring system.

### DIFF
--- a/aesthetic_predictor
+++ b/aesthetic_predictor
@@ -1,2 +1,0 @@
-print(f' wrapper generated at: ')
-print(f' wrapper generated at: ')

--- a/app/scoring.py
+++ b/app/scoring.py
@@ -223,8 +223,6 @@ def score_one_standard(image_path: Path, penalties_dict: dict):
         if _aesthetic_predictor_import_error:
             detected_failure_tags.append("aesthetic_predictor_unavailable")
 
-    import inspect
-    print("evaluate signature:", inspect.signature(_deepdanbooru_module.commands.evaluate))
     # DeepDanbooru 評価呼び出しの直前に追加
 
     # scoring.py の score_one_standard 内 DeepDanbooru 評価部分


### PR DESCRIPTION
The primary cause of the dummy scores was an erroneous `aesthetic_predictor` file in the repository root. This file interfered with the Python import system, preventing the actual `aesthetics_predictor` library from being loaded. This resulted in model initialization failures and the system falling back to assigning dummy scores.

This commit addresses the issue by:
1. Removing the conflicting `aesthetic_predictor` file from the repository root.
2. Removing a leftover debug print statement related to DeepDanbooru integration in `app/scoring.py`.

With these changes, the scoring system should correctly initialize its models and generate actual scores for images instead of dummy ones.