### PR TITLE
Set image gallery gap to zero

### DIFF
--- a/web/viewer/style.css
+++ b/web/viewer/style.css
@@ -149,7 +149,7 @@ main.container {
 .image-gallery {
     display: grid;
     grid-template-columns: repeat(var(--gallery-columns), 1fr); /* CSS変数を使用 */
-    gap: 0.75rem;
+    gap: 0;
 }
 
 .gallery-item {


### PR DESCRIPTION
## Summary
- remove space between images by setting `.image-gallery` gap to zero

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844d9063ab0832d8fea597416ef00dc