### PR TITLE
Refine gallery overlay layout

### DIFF
--- a/web/viewer/style.css
+++ b/web/viewer/style.css
@@ -192,25 +192,35 @@ main.container {
 
 .item-info {
     position: absolute;
-    bottom: 0; left: 0; right: 0;
-    background: rgba(0,0,0,0.6);
-    padding: 0.3rem 0.5rem;
+    bottom: 0;
+    left: 0;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 0.25rem 0.4rem;
     color: white;
     font-size: 0.7rem;
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.1rem;
+    max-width: 75%;
+    border-top-right-radius: var(--border-radius);
+}
+.item-info p {
+    margin: 0;
 }
 .item-info .filename {
     font-weight: 500;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 70%;
+    max-width: 100%;
 }
 .item-info .score {
-    color: var(--accent-color);
+    background-color: var(--accent-color);
+    color: #fff;
     font-weight: bold;
+    padding: 0.05rem 0.3rem;
+    border-radius: 0 var(--border-radius) var(--border-radius) 0;
 }
 
 .delete-btn {


### PR DESCRIPTION
## Summary
- tweak item-info overlay to appear in bottom-left corner
- style score label as accent ribbon

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest -q` *(fails: ModuleNotFoundError for `distutils.tests`)*

------
https://chatgpt.com/codex/tasks/task_e_6844d9145f38832db71ad334d9a0b229