### PR TITLE
Add delete animation and custom sound options

### DIFF
--- a/web/viewer/style.css
+++ b/web/viewer/style.css
@@ -288,3 +288,13 @@ footer {
         margin: 0 0.5rem; 
     }
 }
+
+@keyframes shatter {
+    0% { transform: scale(1) rotate(0deg); opacity: 1; }
+    50% { transform: scale(1.1) rotate(5deg); }
+    100% { transform: scale(1.4) rotate(15deg); opacity: 0; filter: blur(2px); }
+}
+
+.shatter {
+    animation: shatter 0.6s forwards;
+}


### PR DESCRIPTION
## Summary
- animate deletions with new `.shatter` keyframes
- remove images with optional animation instead of re-rendering
- support custom delete sounds and user settings
- ship placeholder directory for custom sounds

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6844d91d4e40832d9978aba0c6bd78fd