### PR TITLE
Add delete image backend and JS call

### DIFF
--- a/web/viewer/api/delete_image.py
+++ b/web/viewer/api/delete_image.py
@@ -1,0 +1,84 @@
+from flask import Flask, request, jsonify
+import json, datetime
+from pathlib import Path
+import os
+
+app = Flask(__name__)
+
+@app.after_request
+def add_cors_headers(resp):
+    resp.headers['Access-Control-Allow-Origin'] = '*'
+    resp.headers['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
+    resp.headers['Access-Control-Allow-Headers'] = 'Content-Type'
+    return resp
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+IMAGES_ORIGINALS_DIR = BASE_DIR / 'images' / 'originals'
+DELETED_DIR = BASE_DIR / 'deleted'
+SCORES_JSON_PATH = BASE_DIR / 'scores.json'
+METADATA_JSON_PATH = BASE_DIR / 'metadata.json'
+DELETE_REQUESTS_JSON_PATH = BASE_DIR / 'delete_requests.json'
+
+def load_json(path, default):
+    if path.exists():
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                return data if isinstance(data, type(default)) else default
+        except Exception:
+            return default
+    return default
+
+
+def save_json(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+@app.route('/api/delete_image', methods=['POST', 'OPTIONS'])
+def delete_image():
+    if request.method == 'OPTIONS':
+        return ('', 200)
+    payload = request.get_json(silent=True) or {}
+    image_id = payload.get('id')
+    if not image_id:
+        return jsonify(success=False, message='id required'), 400
+
+    scores = load_json(SCORES_JSON_PATH, {})
+    metadata = load_json(METADATA_JSON_PATH, {})
+    if image_id not in scores:
+        return jsonify(success=False, message='image not found'), 404
+
+    data = scores.get(image_id, {})
+    filename = data.get('filename', image_id)
+    orig_path = Path(data.get('path', IMAGES_ORIGINALS_DIR / filename))
+    thumb_path = data.get('thumbnail_path_local')
+    dest_dir = DELETED_DIR / datetime.datetime.now().strftime('%Y%m%d')
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        if orig_path.exists():
+            os.rename(orig_path, dest_dir / orig_path.name)
+    except Exception:
+        pass
+    if thumb_path:
+        tp = Path(thumb_path)
+        try:
+            if tp.exists():
+                tp.unlink()
+        except Exception:
+            pass
+
+    scores.pop(image_id, None)
+    metadata.pop(image_id, None)
+    save_json(SCORES_JSON_PATH, scores)
+    save_json(METADATA_JSON_PATH, metadata)
+
+    delete_requests = load_json(DELETE_REQUESTS_JSON_PATH, [])
+    if not any(item.get('id') == image_id for item in delete_requests):
+        delete_requests.append({'id': image_id, 'filename': filename})
+        save_json(DELETE_REQUESTS_JSON_PATH, delete_requests)
+
+    return jsonify(success=True, message='deleted')
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/web/viewer/script.js
+++ b/web/viewer/script.js
@@ -40,6 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const SCORES_JSON_URL = './scores.json';
     const DELETE_REQUESTS_JSON_URL = './delete_requests.json';
     const UPDATE_DELETE_REQUESTS_API_URL = './api/updateDeleteRequests.php';
+    const DELETE_IMAGE_API_URL = './api/delete_image';
 
     function initializeApp() {
         if (currentYearEl) currentYearEl.textContent = new Date().getFullYear();
@@ -226,8 +227,8 @@ document.addEventListener('DOMContentLoaded', () => {
             item.appendChild(infoDiv);
 
             const deleteBtn = document.createElement('button'); deleteBtn.className = 'delete-btn';
-            deleteBtn.innerHTML = '🗑️'; deleteBtn.title = 'この画像を削除リクエスト';
-            deleteBtn.addEventListener('click', (e) => { e.stopPropagation(); handleDeleteRequest(imgData.id, imgData.filename); });
+            deleteBtn.innerHTML = '🗑️'; deleteBtn.title = 'この画像を削除';
+            deleteBtn.addEventListener('click', (e) => { e.stopPropagation(); deleteImage(imgData.id, imgData.filename, item); });
             item.appendChild(deleteBtn);
             gallery.appendChild(item);
         });
@@ -254,6 +255,29 @@ document.addEventListener('DOMContentLoaded', () => {
                 renderGallery(); // UIを即時更新
             } else { throw new Error(result.message || "サーバー処理失敗。"); }
         } catch (error) { console.error('削除リクエストエラー:', error); alert(`削除リクエストエラー: ${error.message}`); }
+    }
+
+    async function deleteImage(imageId, filename, element) {
+        if (!confirm(`画像「${filename}」を完全に削除しますか？`)) return;
+        try {
+            const response = await fetch(DELETE_IMAGE_API_URL, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id: imageId })
+            });
+            if (!response.ok) throw new Error(`サーバーエラー: ${response.status} ${response.statusText}`);
+            const result = await response.json();
+            if (result.success) {
+                delete allImagesData[imageId];
+                element.classList.add('fade-out');
+                element.addEventListener('transitionend', () => element.remove());
+            } else {
+                throw new Error(result.message || '削除に失敗しました');
+            }
+        } catch (err) {
+            console.error('画像削除エラー:', err);
+            alert(`画像削除エラー: ${err.message}`);
+        }
     }
     
     function playDeleteSound() {

--- a/web/viewer/style.css
+++ b/web/viewer/style.css
@@ -237,6 +237,11 @@ main.container {
     background-color: var(--danger-color);
 }
 
+.fade-out {
+    opacity: 0;
+    transition: opacity 0.4s ease-out;
+}
+
 #loadingMessage, #errorMessage, #noImagesMessage {
     grid-column: 1 / -1; text-align: center; padding: 2rem;
     font-size: 1rem; color: var(--text-secondary-color);


### PR DESCRIPTION
## Summary
- create `delete_image.py` endpoint using Flask
- call new endpoint from `deleteImage` in script.js
- update delete button behavior and add fade-out CSS

## Testing
- `python3 -m py_compile web/viewer/api/delete_image.py`

------
https://chatgpt.com/codex/tasks/task_e_6844d924ad64832d8a1734d74b90b88a